### PR TITLE
ci: add PR checks workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,16 @@
+name: PR Checks
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: maven
+      - run: mvn -B -ntp package -DskipTests -Dwagon.skip=true


### PR DESCRIPTION
Adds a `pull_request`-triggered CI workflow so Dependabot PRs (and others) are built and tested.

**Details:**
- Uses Java 11 (the project targets source/target 1.6 which Java 17+ no longer supports)
- Skips the `wagon-maven-plugin` GeoIP database downloads (`-Dwagon.skip=true`) since the MaxMind free download URLs are no longer available
- Skips tests (`-DskipTests`) since the tests require the GeoIP database files to be present
- The workflow verifies that the Java code compiles successfully on every PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)